### PR TITLE
#103 secure user login endpoint

### DIFF
--- a/src/screens/auth/UserLogin.js
+++ b/src/screens/auth/UserLogin.js
@@ -26,7 +26,9 @@ export default class UserLogin extends React.Component {
     }
     onFulfill(code, clear) {
         try{
-            fetch(API.endpoint + `users/${code}`)
+            fetch(API.endpoint + `users/${code}/login`, {
+                method: 'POST'
+            })
             .then((res) => {
                 return res.json();
             })


### PR DESCRIPTION
closes #103

*   secure user login endpoint so that their name is not exposed
*   no API in the app calls `GET` on `/users/uid` so no others changes were needed